### PR TITLE
Support for running yugastore app as docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ To build, simply run the following from the base directory:
 $ mvn -DskipTests package
 ```
 
-To run the app, you need to first install YugaByte DB, create the necessary tables, start each of the microservices and finally the React UI.
+To run the app on host machine, you need to first install YugaByte DB, create the necessary tables, start each of the microservices and finally the React UI.
 
-## Running the app
+## Running the app on host
 
 Make sure you have built the app as described above. Now do the following steps.
 
@@ -126,4 +126,15 @@ $ mvn spring-boot:run
 ```
 
 Now browse to the marketplace app at [http://localhost:8080/](http://localhost:8080/).
+
+# Running the app in docker containers
+
+The dockers images are built along with the binaries when `mvn -DskipTests package` was run.
+To run the docker containers, run the following script, after you have [Installed and initialized YugabyteDB](#step-1-install-and-initialize-yugabyte-db):
+
+```
+$ ./docker-run.sh
+```
+Check all the services are registered on the [eureka-server](https://127.0.0.1/8761/).
+Once all services are registered, you can browse the marketplace app at [http://localhost:8080/](http://localhost:8080/).
 

--- a/api-gateway-microservice/Dockerfile
+++ b/api-gateway-microservice/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:8-jdk-alpine
+COPY ./target/api-gateway-microservice-0.0.1-SNAPSHOT.jar /
+EXPOSE 8081
+ARG ipaddr
+CMD java -jar /api-gateway-microservice-0.0.1-SNAPSHOT.jar --server.port=8081 --eureka.instance.preferIpAddress=true --eureka.instance.hostname=$ipaddr

--- a/api-gateway-microservice/pom.xml
+++ b/api-gateway-microservice/pom.xml
@@ -128,7 +128,25 @@
 		    <groupId>org.springframework.boot</groupId>
 		    <artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
-        
+
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>6.0.17.Final</version>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<version>2.0.1.Final</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator-cdi</artifactId>
+			<version>6.0.17.Final</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -137,6 +155,29 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+            <plugin>
+                 <groupId>org.codehaus.mojo</groupId>
+                 <artifactId>exec-maven-plugin</artifactId>
+                 <version>1.6.0</version>
+                 <executions>
+                     <execution>
+                         <id>docker-build</id>
+                         <phase>package</phase>
+                         <goals>
+                             <goal>exec</goal>
+                         </goals>
+                         <configuration>
+                             <executable>docker</executable>
+                             <arguments>
+                                 <argument>build</argument>
+                                 <argument>-t</argument>
+                                 <argument>yugastore-apiserver:v0.1</argument>
+                                 <argument>.</argument>
+                             </arguments>
+                         </configuration>
+                     </execution>
+                 </executions>
+             </plugin>
 		</plugins>
 	</build>
 
@@ -177,6 +218,4 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
-
-
 </project>

--- a/api-gateway-microservice/src/main/resources/bootstrap.yml
+++ b/api-gateway-microservice/src/main/resources/bootstrap.yml
@@ -4,6 +4,8 @@ spring:
 server:
   port: 8081
 eureka:
+  instance:
+    hostname: localhost
   client:
     serviceUrl:
-      defaultZone: ${EUREKA_URI:http://localhost:8761/eureka}
+      defaultZone: ${EUREKA_URI:http://${eureka.instance.hostname}:8761/eureka}

--- a/cart-microservice/Dockerfile
+++ b/cart-microservice/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:8-jdk-alpine
+COPY ./target/cart-microservice-0.0.1-SNAPSHOT.jar /
+EXPOSE 8083
+ARG ipaddr
+CMD java -jar /cart-microservice-0.0.1-SNAPSHOT.jar --server.port=8083 --eureka.instance.preferIpAddress=true --eureka.instance.hostname=$ipaddr

--- a/cart-microservice/pom.xml
+++ b/cart-microservice/pom.xml
@@ -83,6 +83,29 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>docker-build</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>docker</executable>
+                            <arguments>
+                                <argument>build</argument>
+                                <argument>-t</argument>
+                                <argument>yugastore-cart:v0.1</argument>
+                                <argument>.</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/cart-microservice/src/main/resources/bootstrap.yaml
+++ b/cart-microservice/src/main/resources/bootstrap.yaml
@@ -4,6 +4,8 @@ spring:
 server:
   port: 8083
 eureka:
+  instance:
+    hostname: localhost
   client:
     serviceUrl:
-      defaultZone: ${EUREKA_URI:http://localhost:8761/eureka}
+      defaultZone: ${EUREKA_URI:http://${eureka.instance.hostname}:8761/eureka}

--- a/checkout-microservice/Dockerfile
+++ b/checkout-microservice/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:8-jdk-alpine
+COPY ./target/checkout-microservice-0.0.1-SNAPSHOT.jar /
+EXPOSE 8086
+ARG ipaddr
+CMD java -jar /checkout-microservice-0.0.1-SNAPSHOT.jar --server.port=8086 --eureka.instance.preferIpAddress=true --eureka.instance.hostname=$ipaddr --cronos.yugabyte.hostname=$ipaddr

--- a/checkout-microservice/pom.xml
+++ b/checkout-microservice/pom.xml
@@ -102,6 +102,17 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+		<dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>4.1.27.Final</version>
+            <classifier>linux-x86_64</classifier>
+		</dependency>
+		<dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>6.0.17.Final</version>
+        </dependency>
 	</dependencies>
 	
 	<repositories>
@@ -153,6 +164,29 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>docker-build</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>docker</executable>
+                            <arguments>
+                                <argument>build</argument>
+                                <argument>-t</argument>
+                                <argument>yugastore-checkout:v0.1</argument>
+                                <argument>.</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/checkout-microservice/src/main/resources/bootstrap.yaml
+++ b/checkout-microservice/src/main/resources/bootstrap.yaml
@@ -4,6 +4,8 @@ spring:
 server:
   port: 8083
 eureka:
+  instance:
+    hostname: localhost
   client:
     serviceUrl:
-      defaultZone: ${EUREKA_URI:http://localhost:8761/eureka}
+      defaultZone: ${EUREKA_URI:http://${eureka.instance.hostname}:8761/eureka}

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,105 @@
+# Get ip address on which to run the microservices
+ipaddr=$(hostname -I| cut -d ' ' -f 1)
+
+# Run eureka microservice, assuming the latest entry is to be used
+list=$(docker images | grep 'yugastore-eureka' | head -n 1 )
+image=$(echo $list | cut -d ' ' -f 1)
+version=$(echo $list | cut -d ' ' -f 2)
+
+if [ -z "$image" ]
+then
+    echo "Eureka docker image not found"
+else
+    if [ -z "$version" ]
+    then
+        docker run -e ipaddr=$ipaddr -p 8761:8761 -d $image
+    else
+        docker run -e ipaddr=$ipaddr -p 8761:8761 -d $image:$version
+    fi
+fi
+
+# Run api-gateway microservice, assuming latest entry is to be used
+list=$(docker images | grep 'yugastore-api' | head -n 1 )
+image=$(echo $list | cut -d ' ' -f 1)
+version=$(echo $list | cut -d ' ' -f 2)
+
+if [ -z "$image" ]
+then
+    echo "Api-gateway docker image not found"
+else
+    if [ -z "$version" ]
+    then
+        docker run -e ipaddr=$ipaddr -p 8081:8081 -d $image
+    else
+        docker run -e ipaddr=$ipaddr -p 8081:8081 -d $image:$version
+    fi
+fi
+
+# Run products microservice, assuming latest entry is to be used
+list=$(docker images | grep 'yugastore-products' | head -n 1 )
+image=$(echo $list | cut -d ' ' -f 1)
+version=$(echo $list | cut -d ' ' -f 2)
+
+if [ -z "$image" ]
+then
+    echo "Products docker image not found"
+else
+    if [ -z "$version" ]
+    then
+        docker run -e ipaddr=$ipaddr -p 8082:8082 -d $image
+    else
+        docker run -e ipaddr=$ipaddr -p 8082:8082 -d $image:$version
+    fi
+fi
+
+# Run checkout microservice, assuming latest entry is to be used
+list=$(docker images | grep 'yugastore-checkout' | head -n 1 )
+image=$(echo $list | cut -d ' ' -f 1)
+version=$(echo $list | cut -d ' ' -f 2)
+
+if [ -z "$image" ]
+then
+    echo "checkout docker image not found"
+else
+    if [ -z "$version" ]
+    then
+        docker run -e ipaddr=$ipaddr -p 8086:8086 -d $image
+    else
+        docker run -e ipaddr=$ipaddr -p 8086:8086 -d $image:$version
+    fi
+fi
+
+# Run cart microservice, assuming latest entry is to be used
+list=$(docker images | grep 'yugastore-cart' | head -n 1 )
+image=$(echo $list | cut -d ' ' -f 1)
+version=$(echo $list | cut -d ' ' -f 2)
+
+if [ -z "$image" ]
+then
+    echo "cart docker image not found"
+else
+    if [ -z "$version" ]
+    then
+        docker run -e ipaddr=$ipaddr -p 8083:8083 -d $image
+    else
+        docker run -e ipaddr=$ipaddr -p 8083:8083 -d $image:$version
+    fi
+fi
+
+# Run react-ui microservice, assuming latest entry is to be used
+list=$(docker images | grep 'yugastore-react' | head -n 1 )
+image=$(echo $list | cut -d ' ' -f 1)
+version=$(echo $list | cut -d ' ' -f 2)
+
+if [ -z "$image" ]
+then
+    echo "react-ui docker image not found"
+else
+    if [ -z "$version" ]
+    then
+        docker run -e ipaddr=$ipaddr -p 8080:8080 -d $image
+    else
+        docker run -e ipaddr=$ipaddr -p 8080:8080 -d $image:$version
+    fi
+fi
+

--- a/eureka-server-local/Dockerfile
+++ b/eureka-server-local/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:8-jdk-alpine
+COPY ./target/eureka-server-local-0.0.1-SNAPSHOT.jar /
+EXPOSE 8761
+ARG ipaddr
+CMD java -jar /eureka-server-local-0.0.1-SNAPSHOT.jar --server.port=8761 --eureka.instance.preferIpAddress=true --eureka.instance.ipAddress=$ipaddr

--- a/eureka-server-local/pom.xml
+++ b/eureka-server-local/pom.xml
@@ -24,7 +24,26 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>2.3.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -50,6 +69,29 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>docker-build</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>docker</executable>
+                            <arguments>
+                                <argument>build</argument>
+                                <argument>-t</argument>
+                                <argument>yugastore-eureka-server:v0.1</argument>
+                                <argument>.</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/products-microservice/Dockerfile
+++ b/products-microservice/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:8-jdk-alpine
+COPY ./target/products-microservice-0.0.1-SNAPSHOT.jar /
+EXPOSE 8082
+ARG ipaddr
+CMD java -jar /products-microservice-0.0.1-SNAPSHOT.jar --server.port=8082 --eureka.instance.preferIpAddress=true --eureka.instance.hostname=$ipaddr --cronos.yugabyte.hostname=$ipaddr

--- a/products-microservice/pom.xml
+++ b/products-microservice/pom.xml
@@ -158,7 +158,19 @@
 		    <groupId>org.springframework.boot</groupId>
 		    <artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
-        
+
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-transport-native-epoll</artifactId>
+			<version>4.1.27.Final</version>
+			<classifier>linux-x86_64</classifier>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>6.0.17.Final</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -167,6 +179,29 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+            <plugin>
+                 <groupId>org.codehaus.mojo</groupId>
+                 <artifactId>exec-maven-plugin</artifactId>
+                 <version>1.6.0</version>
+                 <executions>
+                     <execution>
+                         <id>docker-build</id>
+                         <phase>package</phase>
+                         <goals>
+                             <goal>exec</goal>
+                         </goals>
+                         <configuration>
+                             <executable>docker</executable>
+                             <arguments>
+                                 <argument>build</argument>
+                                 <argument>-t</argument>
+                                 <argument>yugastore-products:v0.1</argument>
+                                 <argument>.</argument>
+                             </arguments>
+                         </configuration>
+                     </execution>
+                 </executions>
+             </plugin>
 		</plugins>
 	</build>
 

--- a/products-microservice/src/main/resources/bootstrap.yml
+++ b/products-microservice/src/main/resources/bootstrap.yml
@@ -4,6 +4,8 @@ spring:
 server:
   port: 8082
 eureka:
+  instance:
+    hostname: localhost
   client:
     serviceUrl:
-      defaultZone: ${EUREKA_URI:http://localhost:8761/eureka}
+      defaultZone: ${EUREKA_URI:http://${eureka.instance.hostname}:8761/eureka}

--- a/react-ui/Dockerfile
+++ b/react-ui/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8-jdk-alpine
+COPY ./target/react-ui-0.0.1-SNAPSHOT.jar /
+EXPOSE 8080
+CMD java -jar /react-ui-0.0.1-SNAPSHOT.jar 

--- a/react-ui/frontend/package-lock.json
+++ b/react-ui/frontend/package-lock.json
@@ -4297,7 +4297,7 @@
           "requires": {
             "assert-plus": "0.2.0",
             "jsprim": "1.4.0",
-            "sshpk": "1.13.2"
+            "sshpk": "1.13.0"
           }
         },
         "inflight": {
@@ -4348,7 +4348,8 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -4620,7 +4621,7 @@
           }
         },
         "sshpk": {
-          "version": "1.13.2",
+          "version": "1.13.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -4717,7 +4718,8 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "uid-number": {
           "version": "0.0.6",

--- a/react-ui/pom.xml
+++ b/react-ui/pom.xml
@@ -110,6 +110,30 @@
                         </goals>
                     </execution>
                 </executions>
+	        </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>docker-build</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>docker</executable>
+                            <arguments>
+                                <argument>build</argument>
+                                <argument>-t</argument>
+                                <argument>yugastore-react:v0.1</argument>
+                                <argument>.</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Added support for running Yugastore app as docker containers. Inline with micro-services architecture, each module of the app will run in its own container. Updated the README file with instructions to run it using docker.